### PR TITLE
refactor(executor): defer `Command` creation to when `execute()` called

### DIFF
--- a/crates/volta-core/src/run/executor.rs
+++ b/crates/volta-core/src/run/executor.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 #[cfg(windows)]
 use std::os::windows::process::ExitStatusExt;
-use std::process::{Command, ExitStatus};
+use std::process::ExitStatus;
 
 use super::RECURSION_ENV_VAR;
 use crate::command::create_command;
@@ -113,7 +113,9 @@ impl From<Vec<Executor>> for Executor {
 /// Tracks the Platform as well as what kind of tool is being executed, to allow individual tools
 /// to customize the behavior before execution.
 pub struct ToolCommand {
-    command: Command,
+    exe: OsString,
+    args: Vec<OsString>,
+    envs: Vec<(OsString, OsString)>,
     platform: Option<Platform>,
     kind: ToolKind,
 }
@@ -142,11 +144,17 @@ impl ToolCommand {
         A: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        let mut command = create_command(exe)?;
-        command.args(args);
+        let exe = exe.as_ref().to_owned();
+        let args = args
+            .into_iter()
+            .map(|arg| arg.as_ref().to_owned())
+            .collect();
+        let envs = Vec::new();
 
         Ok(Self {
-            command,
+            exe,
+            args,
+            envs,
             platform,
             kind,
         })
@@ -159,7 +167,10 @@ impl ToolCommand {
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
     {
-        self.command.envs(envs);
+        self.envs.extend(
+            envs.into_iter()
+                .map(|(key, value)| (key.as_ref().to_owned(), value.as_ref().to_owned())),
+        );
     }
 
     /// Adds or updates a single environment variable that the command will use
@@ -168,7 +179,8 @@ impl ToolCommand {
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
     {
-        self.command.env(key, value);
+        self.envs
+            .push((key.as_ref().to_owned(), value.as_ref().to_owned()));
     }
 
     /// Updates the Platform for the command to include values from the command-line
@@ -180,7 +192,7 @@ impl ToolCommand {
     }
 
     /// Runs the command, returning the `ExitStatus` if it successfully launches
-    pub fn execute(mut self, session: &mut Session) -> Fallible<ExitStatus> {
+    pub fn execute(self, session: &mut Session) -> Fallible<ExitStatus> {
         let (path, on_failure) = match self.kind {
             ToolKind::Node => super::node::execution_context(self.platform, session)?,
             ToolKind::Npm => super::npm::execution_context(self.platform, session)?,
@@ -196,11 +208,16 @@ impl ToolCommand {
             ToolKind::Bypass(command) => (System::path()?, ErrorKind::BypassError { command }),
         };
 
-        self.command.env(RECURSION_ENV_VAR, "1");
-        self.command.env("PATH", path);
-
-        pass_control_to_shim();
-        self.command.status().with_context(|| on_failure)
+        create_command(&self.exe)
+            .and_then(|mut command| {
+                command.args(&self.args);
+                command.envs(self.envs);
+                command.env(RECURSION_ENV_VAR, "1");
+                command.env("PATH", path);
+                pass_control_to_shim();
+                command.status().with_context(|| ErrorKind::BinaryExecError)
+            })
+            .with_context(|| on_failure)
     }
 }
 
@@ -215,8 +232,12 @@ impl From<ToolCommand> for Executor {
 /// This will use a `DirectInstall` instance to modify the command before running to point it to
 /// the Volta directory. It will also complete the install, writing config files and shims
 pub struct PackageInstallCommand {
-    /// The command that will ultimately be executed
-    command: Command,
+    /// The executable that should be run
+    exe: &'static str,
+    /// The arguments to pass to the executable
+    args: Vec<OsString>,
+    /// Environment variables to set on the command
+    envs: Vec<(OsString, OsString)>,
     /// The installer that modifies the command as necessary and provides the completion method
     installer: DirectInstall,
     /// The platform to use when running the command.
@@ -231,15 +252,21 @@ impl PackageInstallCommand {
     {
         let installer = DirectInstall::new(manager)?;
 
-        let mut command = match manager {
-            PackageManager::Npm => create_command("npm")?,
-            PackageManager::Pnpm => create_command("pnpm")?,
-            PackageManager::Yarn => create_command("yarn")?,
+        let exe = match manager {
+            PackageManager::Npm => "npm",
+            PackageManager::Pnpm => "pnpm",
+            PackageManager::Yarn => "yarn",
         };
-        command.args(args);
+        let args = args
+            .into_iter()
+            .map(|arg| arg.as_ref().to_owned())
+            .collect();
+        let envs = Vec::new();
 
         Ok(PackageInstallCommand {
-            command,
+            exe,
+            args,
+            envs,
             installer,
             platform,
         })
@@ -252,11 +279,15 @@ impl PackageInstallCommand {
     {
         let installer = DirectInstall::with_name(PackageManager::Npm, name)?;
 
-        let mut command = create_command("npm")?;
-        command.args(args);
+        let args = args
+            .into_iter()
+            .map(|arg| arg.as_ref().to_owned())
+            .collect();
 
         Ok(PackageInstallCommand {
-            command,
+            exe: "npm",
+            args,
+            envs: Vec::new(),
             installer,
             platform,
         })
@@ -269,7 +300,10 @@ impl PackageInstallCommand {
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
     {
-        self.command.envs(envs);
+        self.envs.extend(
+            envs.into_iter()
+                .map(|(key, value)| (key.as_ref().to_owned(), value.as_ref().to_owned())),
+        );
     }
 
     /// Updates the Platform for the command to include values from the command-line
@@ -279,17 +313,20 @@ impl PackageInstallCommand {
 
     /// Runs the install command, applying the necessary modifications to install into the Volta
     /// data directory
-    pub fn execute(mut self, session: &mut Session) -> Fallible<ExitStatus> {
+    pub fn execute(self, session: &mut Session) -> Fallible<ExitStatus> {
         let _lock = VoltaLock::acquire();
         let image = self.platform.checkout(session)?;
         let path = image.path()?;
 
-        self.command.env(RECURSION_ENV_VAR, "1");
-        self.command.env("PATH", path);
-        self.installer.setup_command(&mut self.command);
+        let mut command = create_command(self.exe)?;
+        command.args(&self.args);
+        command.envs(self.envs);
 
-        let status = self
-            .command
+        command.env(RECURSION_ENV_VAR, "1");
+        command.env("PATH", path);
+        self.installer.setup_command(&mut command);
+
+        let status = command
             .status()
             .with_context(|| ErrorKind::BinaryExecError)?;
 
@@ -312,8 +349,10 @@ impl From<PackageInstallCommand> for Executor {
 /// This will set the appropriate environment variables to ensure that the linked package can be
 /// found.
 pub struct PackageLinkCommand {
-    /// The command that will ultimately be executed
-    command: Command,
+    /// The arguments to pass to npm
+    args: Vec<OsString>,
+    /// Environment variables to set on the command
+    envs: Vec<(OsString, OsString)>,
     /// The tool the user wants to link
     tool: String,
     /// The platform to use when running the command
@@ -326,11 +365,15 @@ impl PackageLinkCommand {
         A: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        let mut command = create_command("npm")?;
-        command.args(args);
+        let args = args
+            .into_iter()
+            .map(|arg| arg.as_ref().to_owned())
+            .collect();
+        let envs = Vec::new();
 
         Ok(PackageLinkCommand {
-            command,
+            args,
+            envs,
             tool,
             platform,
         })
@@ -343,7 +386,10 @@ impl PackageLinkCommand {
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
     {
-        self.command.envs(envs);
+        self.envs.extend(
+            envs.into_iter()
+                .map(|(key, value)| (key.as_ref().to_owned(), value.as_ref().to_owned())),
+        );
     }
 
     /// Updates the Platform for the command to include values from the command-line
@@ -355,20 +401,22 @@ impl PackageLinkCommand {
     /// directory.
     ///
     /// This will also check for some common failure cases and alert the user
-    pub fn execute(mut self, session: &mut Session) -> Fallible<ExitStatus> {
+    pub fn execute(self, session: &mut Session) -> Fallible<ExitStatus> {
         self.check_linked_package(session)?;
 
         let image = self.platform.checkout(session)?;
         let path = image.path()?;
 
-        self.command.env(RECURSION_ENV_VAR, "1");
-        self.command.env("PATH", path);
-        let package_root = volta_home()?.package_image_dir(&self.tool);
-        PackageManager::Npm.setup_global_command(&mut self.command, package_root);
+        let mut command = create_command("npm")?;
+        command.args(&self.args);
+        command.envs(self.envs);
 
-        self.command
-            .status()
-            .with_context(|| ErrorKind::BinaryExecError)
+        command.env(RECURSION_ENV_VAR, "1");
+        command.env("PATH", path);
+        let package_root = volta_home()?.package_image_dir(&self.tool);
+        PackageManager::Npm.setup_global_command(&mut command, package_root);
+
+        command.status().with_context(|| ErrorKind::BinaryExecError)
     }
 
     /// Check for possible failure cases with the linked package:
@@ -415,8 +463,12 @@ impl From<PackageLinkCommand> for Executor {
 /// This will use an `InPlaceUpgrade` instance to modify the command and point at the appropriate
 /// image directory. It will also complete the install, writing any updated configs and shims
 pub struct PackageUpgradeCommand {
-    /// The command that will ultimately be executed
-    command: Command,
+    /// The executable that should be run
+    exe: &'static str,
+    /// The arguments to pass to the executable
+    args: Vec<OsString>,
+    /// Environment variables to set on the command
+    envs: Vec<(OsString, OsString)>,
     /// Helper utility to modify the command and provide the completion method
     upgrader: InPlaceUpgrade,
     /// The platform to run the command under
@@ -436,15 +488,21 @@ impl PackageUpgradeCommand {
     {
         let upgrader = InPlaceUpgrade::new(package, manager)?;
 
-        let mut command = match manager {
-            PackageManager::Npm => create_command("npm")?,
-            PackageManager::Pnpm => create_command("pnpm")?,
-            PackageManager::Yarn => create_command("yarn")?,
+        let exe = match manager {
+            PackageManager::Npm => "npm",
+            PackageManager::Pnpm => "pnpm",
+            PackageManager::Yarn => "yarn",
         };
-        command.args(args);
+        let args = args
+            .into_iter()
+            .map(|arg| arg.as_ref().to_owned())
+            .collect();
+        let envs = Vec::new();
 
         Ok(PackageUpgradeCommand {
-            command,
+            exe,
+            args,
+            envs,
             upgrader,
             platform,
         })
@@ -457,7 +515,10 @@ impl PackageUpgradeCommand {
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
     {
-        self.command.envs(envs);
+        self.envs.extend(
+            envs.into_iter()
+                .map(|(key, value)| (key.as_ref().to_owned(), value.as_ref().to_owned())),
+        );
     }
 
     /// Updates the Platform for the command to include values from the command-line
@@ -470,19 +531,22 @@ impl PackageUpgradeCommand {
     ///
     /// Will also check for common failure cases, such as non-existant package or wrong package
     /// manager
-    pub fn execute(mut self, session: &mut Session) -> Fallible<ExitStatus> {
+    pub fn execute(self, session: &mut Session) -> Fallible<ExitStatus> {
         self.upgrader.check_upgraded_package()?;
 
         let _lock = VoltaLock::acquire();
         let image = self.platform.checkout(session)?;
         let path = image.path()?;
 
-        self.command.env(RECURSION_ENV_VAR, "1");
-        self.command.env("PATH", path);
-        self.upgrader.setup_command(&mut self.command);
+        let mut command = create_command(self.exe)?;
+        command.args(&self.args);
+        command.envs(self.envs);
 
-        let status = self
-            .command
+        command.env(RECURSION_ENV_VAR, "1");
+        command.env("PATH", path);
+        self.upgrader.setup_command(&mut command);
+
+        let status = command
             .status()
             .with_context(|| ErrorKind::BinaryExecError)?;
 


### PR DESCRIPTION
This prepares us for a subsequent refactoring of `create_command` in #41 . Deferring the creation of `Command` means we don't need to make a second call to check if an executable exists after refactoring `create_command`. This PR is [a part separated](https://github.com/chawyehsu/volta/compare/8093de44407ca3f144688d53460d0aa4029e748d...a825cf425d6ff5828254ae6d0cd60726215b8458) from #41 and does not contain any functional changes.