### PR TITLE
test(mock-network): remove mockito `SERVER_URL` usage via env and generated hooks

### DIFF
--- a/crates/volta-core/src/tool/node/fetch.rs
+++ b/crates/volta-core/src/tool/node/fetch.rs
@@ -12,26 +12,21 @@ use crate::style::{progress_bar, tool_version};
 use crate::tool::{self, download_tool_error, Node};
 use crate::version::{parse_version, VersionSpec};
 use archive::{self, Archive};
-use cfg_if::cfg_if;
 use fs_utils::ensure_containing_dir_exists;
 use log::debug;
 use node_semver::Version;
 use serde::Deserialize;
 
-cfg_if! {
-    if #[cfg(feature = "mock-network")] {
-        // TODO: We need to reconsider our mocking strategy in light of mockito deprecating the
-        // SERVER_URL constant: Since our acceptance tests run the binary in a separate process,
-        // we can't use `mockito::server_url()`, which relies on shared memory.
-        fn public_node_server_root() -> String {
-            #[allow(deprecated)]
-            mockito::SERVER_URL.to_string()
-        }
-    } else {
-        fn public_node_server_root() -> String {
-            "https://nodejs.org/dist".to_string()
-        }
+fn public_node_server_root() -> String {
+    #[cfg(feature = "mock-network")]
+    if let Some(url) = std::env::var("VOLTA_MOCK_SERVER_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return url;
     }
+
+    "https://nodejs.org/dist".to_string()
 }
 
 fn npm_manifest_path(version: &Version) -> PathBuf {

--- a/crates/volta-core/src/tool/node/resolve.rs
+++ b/crates/volta-core/src/tool/node/resolve.rs
@@ -16,29 +16,23 @@ use crate::tool::Node;
 use crate::version::{VersionSpec, VersionTag};
 use attohttpc::header::HeaderMap;
 use attohttpc::Response;
-use cfg_if::cfg_if;
 use fs_utils::ensure_containing_dir_exists;
 use headers::{CacheControl, Expires, HeaderMapExt};
 use log::debug;
 use node_semver::{Range, Version};
 
 // ISSUE (#86): Move public repository URLs to config file
-cfg_if! {
-    if #[cfg(feature = "mock-network")] {
-        // TODO: We need to reconsider our mocking strategy in light of mockito deprecating the
-        // SERVER_URL constant: Since our acceptance tests run the binary in a separate process,
-        // we can't use `mockito::server_url()`, which relies on shared memory.
-        #[allow(deprecated)]
-        const SERVER_URL: &str = mockito::SERVER_URL;
-        fn public_node_version_index() -> String {
-            format!("{}/node-dist/index.json", SERVER_URL)
-        }
-    } else {
-        /// Returns the URL of the index of available Node versions on the public Node server.
-        fn public_node_version_index() -> String {
-            "https://nodejs.org/dist/index.json".to_string()
-        }
+/// Returns the URL of the index of available Node versions on the public Node server.
+fn public_node_version_index() -> String {
+    #[cfg(feature = "mock-network")]
+    if let Some(url) = std::env::var("VOLTA_MOCK_SERVER_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return format!("{}/node-dist/index.json", url);
     }
+
+    "https://nodejs.org/dist/index.json".to_string()
 }
 
 pub fn resolve(matching: VersionSpec, session: &mut Session) -> Fallible<Version> {

--- a/crates/volta-core/src/tool/registry.rs
+++ b/crates/volta-core/src/tool/registry.rs
@@ -8,7 +8,6 @@ use crate::style::progress_spinner;
 use crate::version::{hashmap_version_serde, version_serde};
 use attohttpc::header::ACCEPT;
 use attohttpc::Response;
-use cfg_if::cfg_if;
 use node_semver::Version;
 use serde::Deserialize;
 
@@ -17,21 +16,16 @@ use serde::Deserialize;
 pub const NPM_ABBREVIATED_ACCEPT_HEADER: &str =
     "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*";
 
-cfg_if! {
-    if #[cfg(feature = "mock-network")] {
-        // TODO: We need to reconsider our mocking strategy in light of mockito deprecating the
-        // SERVER_URL constant: Since our acceptance tests run the binary in a separate process,
-        // we can't use `mockito::server_url()`, which relies on shared memory.
-        #[allow(deprecated)]
-        const SERVER_URL: &str = mockito::SERVER_URL;
-        pub fn public_registry_index(package: &str) -> String {
-            format!("{}/{}", SERVER_URL, package)
-        }
-    } else {
-        pub fn public_registry_index(package: &str) -> String {
-            format!("https://registry.npmjs.org/{}", package)
-        }
+pub fn public_registry_index(package: &str) -> String {
+    #[cfg(feature = "mock-network")]
+    if let Some(url) = std::env::var("VOLTA_MOCK_SERVER_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return format!("{}/{}", url, package);
     }
+
+    format!("https://registry.npmjs.org/{}", package)
 }
 
 // fetch a registry that returns info in Npm format

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -705,6 +705,15 @@ impl SandboxBuilder {
         }
 
         // write files
+        if !self
+            .files
+            .iter()
+            .any(|file| file.path == default_hooks_file())
+        {
+            let hooks = sandbox_default_hooks_json();
+            self = self.default_hooks(&hooks);
+        }
+
         for file_builder in self.files {
             file_builder.build();
         }
@@ -724,6 +733,41 @@ impl SandboxBuilder {
     fn rm_root(&self) {
         self.root.root().rm_rf()
     }
+}
+
+fn sandbox_default_hooks_json() -> String {
+    format!(
+        r#"{{
+    "node": {{
+        "index": {{
+            "template": "{0}/node-dist/{{{{filename}}}}"
+        }},
+        "latest": {{
+            "template": "{0}/node-dist/{{{{filename}}}}"
+        }},
+        "distro": {{
+            "template": "{0}/v{{{{version}}}}/{{{{filename}}}}"
+        }}
+    }},
+    "npm": {{
+        "index": {{
+            "template": "{0}/{{{{filename}}}}"
+        }},
+        "distro": {{
+            "template": "{0}/npm/-/{{{{filename}}}}"
+        }}
+    }},
+    "pnpm": {{
+        "index": {{
+            "template": "{0}/{{{{filename}}}}"
+        }},
+        "distro": {{
+            "template": "{0}/pnpm/-/{{{{filename}}}}"
+        }}
+    }}
+}}"#,
+        mockito::server_url()
+    )
 }
 
 // files and dirs in the sandbox
@@ -856,6 +900,7 @@ impl Sandbox {
             .env("VOLTA_HOME", volta_home())
             .env("VOLTA_INSTALL_DIR", cargo_dir())
             .env("PATH", &self.path)
+            .env("VOLTA_MOCK_SERVER_URL", mockito::server_url())
             .env("VOLTA_POSTSCRIPT", volta_postscript())
             .env_remove("VOLTA_SHELL")
             .env_remove("MSYSTEM"); // assume cmd.exe everywhere on windows


### PR DESCRIPTION
`mockito::SERVER_URL` is a depercated API, the usage is a blocker of #34.

This relates to https://github.com/volta-cli/volta/pull/1099 and https://github.com/volta-cli/volta/issues/145