### PR TITLE
refactor: return ExitCode from main instead of process::exit

### DIFF
--- a/crates/volta-core/src/error/mod.rs
+++ b/crates/volta-core/src/error/mod.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::fmt;
-use std::process::exit;
 
 mod kind;
 mod reporter;
@@ -124,7 +123,10 @@ pub enum ExitCode {
 }
 
 impl ExitCode {
-    pub fn exit(self) -> ! {
-        exit(self as i32);
+    pub fn exit(self) -> std::process::ExitCode {
+        match self {
+            ExitCode::Success => std::process::ExitCode::SUCCESS,
+            _ => std::process::ExitCode::from(self as u8),
+        }
     }
 }

--- a/crates/volta-core/src/session.rs
+++ b/crates/volta-core/src/session.rs
@@ -3,7 +3,6 @@
 //! hook configuration, and the state of the local inventory.
 
 use std::fmt::{self, Display, Formatter};
-use std::process::exit;
 
 use crate::error::{ExitCode, Fallible, VoltaError};
 use crate::event::EventLog;
@@ -177,7 +176,13 @@ impl Session {
 
     pub fn exit_tool(self, code: i32) -> std::process::ExitCode {
         self.publish_to_event_log();
-        exit(code)
+        // NOTE: Due to limitations in the Rust standard library, there is
+        // currently no suitable way to convert a massive Windows system error
+        // code (or negative exit code) into a `ExitCode` with `u8` inner code;
+        // for the time being, we are using `ExitCode::FAILURE`.
+        u8::try_from(code)
+            .map(std::process::ExitCode::from)
+            .unwrap_or(std::process::ExitCode::FAILURE)
     }
 }
 

--- a/crates/volta-core/src/session.rs
+++ b/crates/volta-core/src/session.rs
@@ -170,14 +170,14 @@ impl Session {
         }
     }
 
-    pub fn exit(self, code: ExitCode) -> ! {
+    pub fn exit(self, code: ExitCode) -> std::process::ExitCode {
         self.publish_to_event_log();
-        code.exit();
+        code.exit()
     }
 
-    pub fn exit_tool(self, code: i32) -> ! {
+    pub fn exit_tool(self, code: i32) -> std::process::ExitCode {
         self.publish_to_event_log();
-        exit(code);
+        exit(code)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod common;
 use common::{ensure_layout, Error};
 
 /// The entry point for the `volta` CLI.
-pub fn main() {
+pub fn main() -> std::process::ExitCode {
     let volta = cli::Volta::parse();
     let verbosity = match (&volta.verbose, &volta.quiet) {
         (false, false) => LogVerbosity::Default,
@@ -38,18 +38,18 @@ pub fn main() {
     match result {
         Ok(exit_code) => {
             session.add_event_end(ActivityKind::Volta, exit_code);
-            session.exit(exit_code);
+            session.exit(exit_code)
         }
         Err(Error::Tool(code)) => {
             session.add_event_tool_end(ActivityKind::Volta, code);
-            session.exit_tool(code);
+            session.exit_tool(code)
         }
         Err(Error::Volta(err)) => {
             report_error(env!("CARGO_PKG_VERSION"), &err);
             session.add_event_error(ActivityKind::Volta, &err);
             let code = err.exit_code();
             session.add_event_end(ActivityKind::Volta, code);
-            session.exit(code);
+            session.exit(code)
         }
     }
 }

--- a/src/volta-migrate.rs
+++ b/src/volta-migrate.rs
@@ -3,7 +3,7 @@ use volta_core::layout::volta_home;
 use volta_core::log::{LogContext, LogVerbosity, Logger};
 use volta_migrate::run_migration;
 
-pub fn main() {
+pub fn main() -> std::process::ExitCode {
     Logger::init(LogContext::Migration, LogVerbosity::Default)
         .expect("Only a single Logger should be initialized");
 
@@ -11,7 +11,7 @@ pub fn main() {
     // the Homebrew formula runs volta-migrate with `--no-create` flag in the post-install phase.
     let no_create = matches!(std::env::args_os().nth(1), Some(flag) if flag == "--no-create");
     if no_create && volta_home().map_or(true, |home| !home.root().exists()) {
-        ExitCode::Success.exit();
+        return ExitCode::Success.exit();
     }
 
     let exit_code = match run_migration() {
@@ -22,5 +22,5 @@ pub fn main() {
         }
     };
 
-    exit_code.exit();
+    exit_code.exit()
 }

--- a/src/volta-shim.rs
+++ b/src/volta-shim.rs
@@ -7,7 +7,7 @@ use volta_core::run::execute_shim;
 use volta_core::session::{ActivityKind, Session};
 use volta_core::signal::setup_signal_handler;
 
-pub fn main() {
+pub fn main() -> std::process::ExitCode {
     Logger::init(LogContext::Shim, LogVerbosity::Default)
         .expect("Only a single Logger should be initialized");
     setup_signal_handler();
@@ -19,17 +19,17 @@ pub fn main() {
     match result {
         Ok(()) => {
             session.add_event_end(ActivityKind::Tool, ExitCode::Success);
-            session.exit(ExitCode::Success);
+            session.exit(ExitCode::Success)
         }
         Err(Error::Tool(code)) => {
             session.add_event_tool_end(ActivityKind::Tool, code);
-            session.exit_tool(code);
+            session.exit_tool(code)
         }
         Err(Error::Volta(err)) => {
             report_error(env!("CARGO_PKG_VERSION"), &err);
             session.add_event_error(ActivityKind::Tool, &err);
             session.add_event_end(ActivityKind::Tool, err.exit_code());
-            session.exit(ExitCode::ExecutionFailure);
+            session.exit(ExitCode::ExecutionFailure)
         }
     }
 }


### PR DESCRIPTION
Due to issues https://github.com/taiki-e/cargo-llvm-cov/issues/235 with `cargo llvm-cov` and its upstream dependencies regarding the collecting of codecov reports for programs that use `process::exit()`, improving test coverage has been difficult. This PR attempts to address this by returning an `ExitCode` directly, rather than explicitly terminating the process with `exit()`.